### PR TITLE
FIX bug/IDAS-20513:  iotgent does not send correct updateContext information, when the device has entity_name by default (device_id:entity_type)

### DIFF
--- a/src/app/main.cc
+++ b/src/app/main.cc
@@ -237,7 +237,7 @@ int main(int argc, char* argv[]) {
                                         true));
 
   log4cplus::tstring pattern =
-    LOG4CPLUS_TEXT("time=%D{%Y-%m-%dT%H-%M-%S,%Q%Z} | lvl=%5p | comp=" +
+    LOG4CPLUS_TEXT("time=%D{%Y-%m-%dT%H:%M:%S,%Q%Z} | lvl=%5p | comp=" +
                    component_name +
                    " | op=%M | file=[%t:%b:%L] | msg=%m %n");
   //LOG4CPLUS_TEXT("%-5p %D{%d-%m-%y %H:%M:%S,%Q %Z} [%t][%b] - %m %n");

--- a/src/rest/command_handle.cc
+++ b/src/rest/command_handle.cc
@@ -1329,7 +1329,9 @@ int iota::CommandHandle::send(
   iota::UpdateContext op(updateAction);
   op.add_context_element(ngsi_context_element);
 
-  return cb_comm->async_send(cb_url, op.get_string(), service,
+  std::string toCV = op.get_string();
+  PION_LOG_DEBUG(m_logger, ":send2CB:" <<cb_url << ":body:" << toCV);
+  return cb_comm->async_send(cb_url, toCV, service,
                              boost::bind(&iota::CommandHandle::handle_updateContext, this, cb_url, _1, _2));
 }
 
@@ -1437,7 +1439,6 @@ int iota::CommandHandle::send_updateContext(
   std::string date_to_cb = mi_hora.toUTC().toString();
   iota::Attribute timeAT("TimeInstant", "ISO8601", date_to_cb);
   ngsi_context_element.add_attribute(timeAT);
-  PION_LOG_DEBUG(m_logger,"<<<" << ngsi_context_element.get_string());
 
   ngsi_context_element.set_env_info(service, item_dev);
 
@@ -1474,7 +1475,6 @@ int iota::CommandHandle::send_updateContext(
   std::string date_to_cb = mi_hora.toUTC().toString();
   iota::Attribute timeAT("TimeInstant", "ISO8601", date_to_cb);
   ngsi_context_element.add_attribute(timeAT);
-  PION_LOG_DEBUG(m_logger,"<<<" << ngsi_context_element.get_string());
 
   ngsi_context_element.set_env_info(service, item_dev);
 
@@ -1514,7 +1514,7 @@ void iota::CommandHandle::save_command(const std::string& command_name,
                  " id:" <<  command_id << " service:" << service <<
                  " service_path:" << service_path <<
                  " name:" << command_name <<
-                 " sequence:" << sequence << "device:" << item_dev->_name <<
+                 " sequence:" << sequence << "device:" << item_dev->get_real_name() <<
                  " endpoint:" << endpoint << "timeout:" << timeout);
 
   boost::shared_ptr<Command> item(new Command(command_id, command_name,

--- a/src/services/admin_mgmt_service.cc
+++ b/src/services/admin_mgmt_service.cc
@@ -277,7 +277,7 @@ int iota::AdminManagerService::get_all_devices_json(
                protocol_filter);
   }
   catch (iota::IotaException& e) {
-    PION_LOG_ERROR(log_message, e.what());
+    PION_LOG_ERROR(m_log, log_message << e.what());
   }
   std::map<std::string, std::string> response_from_iotagent;
   std::map<std::string, std::string> response_from_iotagent_nok;

--- a/src/util/device.h
+++ b/src/util/device.h
@@ -176,7 +176,11 @@ struct Device : public virtual Timer {
 
   std::string get_real_name() const {
     if (_entity_name.empty()) {
-      return _name;
+        if (_entity_type.empty()){
+          return "thing:"+_name;
+        }else{
+          return _entity_type+":"+_name;
+        }
     }
     else {
       return _entity_name;

--- a/tests/iotagent/ul20Test.cc
+++ b/tests/iotagent/ul20Test.cc
@@ -129,7 +129,7 @@ Ul20Test::POST_DEVICE_CON("{\"devices\": "
                        "}]}");
 const std::string
 Ul20Test::POST_DEVICE_CON2("{\"devices\": "
-                       "[{\"device_id\": \"unitTest_dev32_polling\",\"protocol\": \"PDI-IoTA-UltraLight\",\"entity_name\": \"room_ut32\",\"entity_type\": \"type2\",\"timezone\": \"America/Santiago\","
+                       "[{\"device_id\": \"unitTest_dev32_polling\",\"protocol\": \"PDI-IoTA-UltraLight\",\"entity_type\": \"type2\",\"timezone\": \"America/Santiago\","
                        "\"commands\": [{\"name\": \"PING\",\"type\": \"command\",\"value\": \"unitTest_dev32_polling@command|%s\" }],"
                        "\"attributes\": [{\"object_id\": \"temp\",\"name\": \"temperature\",\"type\": \"int\" }]"
                        ",\"static_attributes\": [{\"name\": \"humidity\",\"type\": \"int\", \"value\": \"50\"  }]"
@@ -2596,7 +2596,7 @@ void Ul20Test::testPollingCommand_MONGO_CON() {
        "room_ut3", "type2", POST_DEVICE_CON, cb_mock);
   std::cout << "@UT@Second command" <<  service << std::endl;
   testPollingCommand_MONGO("unitTest_dev32_polling",
-       "room_ut32", "type2", POST_DEVICE_CON2, cb_mock);
+       "type2:unitTest_dev32_polling", "type2", POST_DEVICE_CON2, cb_mock);
 
   std::cout << "@UT@DELETE Service" << std::endl;
   std::string token, trace_message;


### PR DESCRIPTION
… device produces entiy_type:device_name, more log about data send to CB, error detected with ubuntu PION_LO_ERROR(log_message
