### PR TITLE
Update Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -53,7 +53,7 @@ RUN yum -y remove autoconf automake bzip2-devel \
  RUN cd ${GIT_PATH_IOTACPP} && \
     cd build/${IOTACPP_BUILD_TYPE} && \
     cd pack/Linux/RPM && \
-    curl -kOL http://download.opensuse.org/repositories/home:/oojah:/mqtt/CentOS_CentOS-5/home:oojah:mqtt.repo && \
+    curl -kOL http://download.opensuse.org/repositories/home:/oojah:/mqtt/CentOS_CentOS-6/home:oojah:mqtt.repo && \
     mv home:oojah:mqtt.repo /etc/yum.repos.d/ && \
     yum localinstall -y iot-agent-*.rpm && \
     yum clean all && \


### PR DESCRIPTION
During the docker-compose procedure:
Error: File contains no section headers.
file: file:///etc/yum.repos.d/home:oojah:mqtt.repo, line: 1
'<?xml version="1.0" encoding="ISO-8859-1"?>\n'
Service 'iotacpp' failed to build: The command '/bin/sh -c cd ${GIT_PATH_IOTACPP} &&     cd build/${IOTACPP_BUILD_TYPE} &&     cd pack/Linux/RPM &&     curl -kOL http://download.opensuse.org/repositories/home:/oojah:/mqtt/CentOS_CentOS-5/home:oojah:mqtt.repo &&     mv home:oojah:mqtt.repo /etc/yum.repos.d/ &&     yum localinstall -y iot-agent-*.rpm &&     yum clean all &&     chkconfig iotagent on' returned a non-zero code: 1
Fix setting the correct CentOS version.
