### PR TITLE
FIX DM-1218: Log with level INFO is malformed and alarm code 1 is not…

### DIFF
--- a/BaseChangeLog.txt
+++ b/BaseChangeLog.txt
@@ -9,6 +9,7 @@
 - FIX DM-1115: if ContextBroker response 502, ul2, respsol, modbus must create an alarm with service, subservice
 - FIX DM-1120: Check if command is full confirmed (echo response).
 - FIX DM-1123: Command response must have length 8 (strictly).
+- FIX DM-1218: Log with level INFO is malformed and alarm code "1" is not supported by O&M (changed to 999).
 
 * Wed Sep 30 2015 Agustin Gonzalez <lucas@tid.es> 1.2.1
 - FEATURE IDAS-20527: New identifier for IoTAgent if dynamic address is a problem.

--- a/src/app/main.cc
+++ b/src/app/main.cc
@@ -150,7 +150,7 @@ int main(int argc, const char* argv[]) {
 
   log4cplus::tstring pattern =
 
-      LOG4CPLUS_TEXT("time=%D{%Y-%m-%dT%H:%M:%S,%Q%Z} | lvl=%5p | comp=" +
+      LOG4CPLUS_TEXT("time=%D{%Y-%m-%dT%H:%M:%S,%Q%Z} | lvl=%-5p | comp=" +
                      arguments.get_component_name() + " %m %n");
   // LOG4CPLUS_TEXT("%-5p %D{%d-%m-%y %H:%M:%S,%Q %Z} [%t][%b] - %m %n");
 

--- a/src/rest/types.cc
+++ b/src/rest/types.cc
@@ -218,7 +218,7 @@ const unsigned int types::RESPONSE_CODE_FIWARE_SERVICE_PATH_ERROR = 1001;
 const unsigned int types::RESPONSE_CODE_FORBIDDEN_CHARACTERS = 1002;
 
 /// ALARMS
-const unsigned int types::ALARM_CODE_BAD_CONFIGURATION = 1;
+const unsigned int types::ALARM_CODE_BAD_CONFIGURATION = 999;
 const unsigned int types::ALARM_CODE_NO_MONGO = 100;
 const unsigned int types::ALARM_CODE_NO_CB = 200;
 const unsigned int types::ALARM_CODE_NO_IOTA = 300;


### PR DESCRIPTION
… supported by O&M (changed to 999).
